### PR TITLE
[fix] Display real energy values on y axis in plot_energies script

### DIFF
--- a/plot_energies.py
+++ b/plot_energies.py
@@ -38,7 +38,8 @@ if we_continue:
 		if re.search("Total Energy       :     ", line):
 			temp = line.split()[3]
 			Energy.append(temp)
-			
+# convert string to float
+	Energy=[(lambda x: float(x))(x) for x in Energy]
 	
 
 # ------------- PLOTTING STUFF ------------- #			


### PR DESCRIPTION
Previously string values were used instead of float ones and the plot
has been obtained upside down without correct y-axis ticks (python2.7)